### PR TITLE
Refactor for compatibility with Rust 1.14

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,14 +1,8 @@
-#![feature(phase)]
-
-extern crate test;
-extern crate entity_system;
-
-#[phase(plugin)]
 extern crate entity_system;
 
 mod test_entity_manager {
     extern crate entity_system;
-    use entity_system::{EntityManager};
+    use entity_system::EntityManager;
 
     #[test]
     fn new_entities_are_unique() {
@@ -37,12 +31,12 @@ mod test_component_manager {
     extern crate entity_system;
     use entity_system::{EntityManager, ComponentManager};
 
-    #[deriving(Clone)]
+    #[derive(Clone)]
     pub struct TestComponent {
         pub name: &'static str,
     }
 
-    #[deriving(Clone)]
+    #[derive(Clone)]
     pub struct OtherComponent {
         pub name: &'static str,
     }


### PR DESCRIPTION
I was happy to find this library, having struggled to write something similar but much worse, so thanks for this!

The changes in this PR are:

* deriving is now derive
* TypeId has moved to std::any
* The HashMap Entry API is improved, more succinct
* Have to import traits you reference now (e.g. std::ops::Index)
* .index doesn't take a reference to an index now
* Removed feature phase stuff, which I think is obsolete now